### PR TITLE
Add os.clock() timestamp to attack log entries

### DIFF
--- a/src/HitboxViewer/config/defaults/lang.lua
+++ b/src/HitboxViewer/config/defaults/lang.lua
@@ -90,7 +90,7 @@ return {
             header_stun = "Stun",
             header_damage_angle = "Damage Angle",
             header_guard_type = "Guard Type",
-            header_os_clock = "os.clock()",
+            header_os_clock = "Timestamp (seconds)",
             header_more_data = "More Data",
             header_key = "Key",
             header_value = "Value",

--- a/src/HitboxViewer/config/defaults/lang.lua
+++ b/src/HitboxViewer/config/defaults/lang.lua
@@ -90,6 +90,7 @@ return {
             header_stun = "Stun",
             header_damage_angle = "Damage Angle",
             header_guard_type = "Guard Type",
+            header_os_clock = "os.clock()",
             header_more_data = "More Data",
             header_key = "Key",
             header_value = "Value",

--- a/src/HitboxViewer/gui/attack_log.lua
+++ b/src/HitboxViewer/gui/attack_log.lua
@@ -13,7 +13,7 @@ local this = {
         name = "attack_log",
         -- BordersH, BordersInnerH, Sortable, BordersOuterV, SizingStretchProp, ContextMenuInBody, Hideable
         flags = 26021,
-        col_count = 15,
+        col_count = 16,
         headers = {
             "row",
             "char_type",
@@ -29,6 +29,7 @@ local this = {
             "part_break",
             "stun",
             "sharpness",
+            "os_clock",
             "more_data",
         },
     },


### PR DESCRIPTION
Heya, awesome mod and nice codebase! I've been playing around with this mod and I've found it really useful for in-game frame data analysis. One enhancement that would really help is if the attack log had timestamps for computing deltas between (preferably at millisecond precision), as currently I'm manually counting frames which is tedious as hell.

I had a go at implementing this and it seems to be working well, so thought it might be a good enhancement to contribute back. Happy to take feedback, and feel free to close if it's not something you want to add!